### PR TITLE
docs(adr): add ADR-001 client-only processing for v1

### DIFF
--- a/docs/adr/docs/adr/0000-template.md
+++ b/docs/adr/docs/adr/0000-template.md
@@ -1,0 +1,21 @@
+# {short title}
+
+- **Status:** Proposed | Accepted | Rejected | Superseded
+- **Date:** YYYY-MM-DD
+- **Owner:** Your Name
+
+## Context and Problem Statement
+{2–3 sentences describing the situation, constraints, and the architectural question. Link issues/PRs if helpful.}
+
+## Considered Options
+- {Option 1}
+- {Option 2}
+- {Option 3}
+
+## Decision Outcome
+Chosen option: **{Option 1}**, because {key justification; why this beats the others}.
+
+## Consequences
+- Good: {positive outcome(s)}
+- Bad: {trade-offs / liabilities}
+- Notes: {follow-ups, review points, or exit criteria}

--- a/docs/adr/docs/adr/0001-client-only-processing.md
+++ b/docs/adr/docs/adr/0001-client-only-processing.md
@@ -1,0 +1,21 @@
+# Client-only processing for v1
+
+- **Status:** Accepted
+- **Date:** 2025-09-10
+- **Owner:** Danny Mendoza
+
+## Context and Problem Statement
+We must process potentially sensitive accounting data (PII/financial) while deploying as a static site (GitHub Pages). How do we minimize data exposure and keep the MVP auditable and simple?
+
+## Considered Options
+- Process everything client-side (no server; browser-only)
+- Introduce a minimal backend now (API for parsing/grouping; enable auth/settings early)
+- Hybrid (client parsing; server for persistence/auth or heavy compute)
+
+## Decision Outcome
+Chosen option: **Process everything client-side**, because it eliminates **most** risk of data leaving the user's machine, simplifies deployment/operations for the MVP, and keeps the logic deterministic and easy to test.
+
+## Consequences
+- Good: No user data leaves the device; static hosting is simple; fast time-to-value; clear auditability.
+- Bad: No server features in v1 (no auth, no cross-device settings, no server logs); memory limits for very large files; careful UX needed for large datasets.
+- Notes: If we later need authenticated settings, collaboration, auditing, or heavier compute (e.g., advanced fuzzy matching), we will propose a small backend (exit criteria).


### PR DESCRIPTION
## Summary
Document the v1 decision to run all parsing/normalization/grouping **entirely in the browser**. This ADR formalizes our privacy-first stance, establishes static deployment on GitHub Pages, and defines when we would later introduce a backend.

## Linked Issue
Closes #2

## Scope
- [x] Documentation-only (no code changes)

## Changes
- Added `docs/adr/0001-client-only-processing.md`:
  - Context & problem statement (PII, static hosting)
  - Options considered (client-only, minimal backend now, hybrid)
  - Decision: client-only for v1
  - Consequences: pros/trade-offs; local limits
  - **Exit criteria** for revisiting (auth, audit trails, heavier compute, UX/perf ceilings)

## Acceptance Criteria (from issue)
- [x] ADR describes options (client-only vs backend now)
- [x] ADR explains rationale and consequences
- [x] File added at `/docs/adr/0001-client-only-processing.md`
- [x] Template added at `/docs/adr/0000-template.md`

## Notes for Reviewers
- This ADR is intentionally narrow (one decision per record) to keep the decision log clear and supersedable.
- Follow-ups: ADR-002 (data handling & storage), ADR-003 (matching strategy).
